### PR TITLE
Added support for IHttpClientFactory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Added support for the `IHttpClientBuilder` methods.
+
 ### Changed
+
+- [BREAKING]: Removed the `innerHandler` parameter in the `RequestsSignatureDelegatingHandler` constructor; you must now use the `InnerHandler` property.
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- Support for working with `IHttpClientFactory` ([Issue #2](https://github.com/nventive/RequestsSignature/issues/2)).
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -220,10 +220,23 @@ var client = new System.Net.Http.HttpClient(
             // These options must be the same as the server-side client options.
             ClientId = "9e616f36fde8424e9f71afa4a31e128a",
             ClientSecret = "df46ca91155142e99617a5fc5dea1f50",
-        }));
+        })
+    {
+        InnerHandler = new HttpClientHandler(),
+    });
 
 // Use the client normally
 var response = await client.GetAsync("...");
+
+// Or register it with the IHttpClientFactory
+services
+    .AddHttpClient<IService>()
+    .AddRequestsSignature(
+        new RequestsSignatureOptions
+        {
+            ClientId = StartupWithMiddleware.DefaultClientId,
+            ClientSecret = StartupWithMiddleware.DefaultClientSecret,
+        });
 ```
 
 ### Testing with [Postman](https://www.getpostman.com/)

--- a/RequestsSignature.HttpClient.Tests/HttpClientFactoryTests.cs
+++ b/RequestsSignature.HttpClient.Tests/HttpClientFactoryTests.cs
@@ -1,0 +1,73 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using RequestsSignature.AspNetCore;
+using RequestsSignature.HttpClient.Tests.Server;
+using Xunit;
+
+namespace RequestsSignature.HttpClient.Tests
+{
+    [Collection(nameof(ServerWithMiddlewareCollection))]
+    public class HttpClientFactoryTests
+    {
+        private readonly ServerFixture<StartupWithMiddleware> _fixture;
+
+        public HttpClientFactoryTests(ServerFixture<StartupWithMiddleware> fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task ItShouldWorkWithHttpClientFactoryWithNoOptions()
+        {
+            var services = new ServiceCollection();
+            services
+                .AddSingleton(new RequestsSignatureOptions
+                {
+                    ClientId = StartupWithMiddleware.DefaultClientId,
+                    ClientSecret = StartupWithMiddleware.DefaultClientSecret,
+                })
+                .AddHttpClient(
+                    "TheClient",
+                    options =>
+                    {
+                        options.BaseAddress = _fixture.ServerUri;
+                    })
+                .AddRequestsSignature();
+
+            var client = services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>().CreateClient("TheClient");
+            var response = await client.GetAsync(ApiController.GetSignatureValidationResultGetUri);
+
+            var result = await response.Content.ReadAsAsync<SignatureValidationResult>();
+
+            result.Status.Should().Be(SignatureValidationResultStatus.OK);
+            result.ClientId.Should().Be(StartupWithMiddleware.DefaultClientId);
+        }
+
+        [Fact]
+        public async Task ItShouldWorkWithHttpClientFactoryWithOptions()
+        {
+            var services = new ServiceCollection();
+            services.AddHttpClient(
+                "TheClient",
+                options =>
+                {
+                    options.BaseAddress = _fixture.ServerUri;
+                })
+                .AddRequestsSignature(new RequestsSignatureOptions
+                {
+                    ClientId = StartupWithMiddleware.DefaultClientId,
+                    ClientSecret = StartupWithMiddleware.DefaultClientSecret,
+                });
+
+            var client = services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>().CreateClient("TheClient");
+            var response = await client.GetAsync(ApiController.GetSignatureValidationResultGetUri);
+
+            var result = await response.Content.ReadAsAsync<SignatureValidationResult>();
+
+            result.Status.Should().Be(SignatureValidationResultStatus.OK);
+            result.ClientId.Should().Be(StartupWithMiddleware.DefaultClientId);
+        }
+    }
+}

--- a/RequestsSignature.HttpClient/HttpClientBuilderExtensions.cs
+++ b/RequestsSignature.HttpClient/HttpClientBuilderExtensions.cs
@@ -1,0 +1,30 @@
+﻿using RequestsSignature.Core;
+using RequestsSignature.HttpClient;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// <see cref="IHttpClientBuilder"/> extension methods.
+    /// </summary>
+    public static class HttpClientBuilderExtensions
+    {
+        /// <summary>
+        /// Adds <see cref="RequestsSignatureDelegatingHandler"/> as a HttpMessageHandler in the client pipeline.
+        /// </summary>
+        /// <param name="httpClientBuilder">The <see cref="IHttpClientBuilder"/>.</param>
+        /// <param name="options">The <see cref="RequestsSignatureOptions"/> to use. If not provided will retrieve from the container.</param>
+        /// <param name="signatureBodySourceBuilder">The <see cref="ISignatureBodySourceBuilder"/>. If not provided will try to retrieve from the container.</param>
+        /// <param name="signatureBodySigner">The <see cref="ISignatureBodySigner"/>. If not provided will try to retrieve from the container.</param>
+        /// <returns>The updated <see cref="IHttpClientBuilder"/>.</returns>
+        public static IHttpClientBuilder AddRequestsSignature(
+            this IHttpClientBuilder httpClientBuilder,
+            RequestsSignatureOptions options = null,
+            ISignatureBodySourceBuilder signatureBodySourceBuilder = null,
+            ISignatureBodySigner signatureBodySigner = null)
+                => httpClientBuilder.AddHttpMessageHandler(
+                    (sp) => new RequestsSignatureDelegatingHandler(
+                        options ?? sp.GetRequiredService<RequestsSignatureOptions>(),
+                        signatureBodySourceBuilder: signatureBodySourceBuilder ?? sp.GetService<ISignatureBodySourceBuilder>(),
+                        signatureBodySigner: signatureBodySigner ?? sp.GetService<ISignatureBodySigner>()));
+    }
+}

--- a/RequestsSignature.HttpClient/RequestsSignature.HttpClient.csproj
+++ b/RequestsSignature.HttpClient/RequestsSignature.HttpClient.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
   </ItemGroup>
 

--- a/RequestsSignature.HttpClient/RequestsSignatureDelegatingHandler.cs
+++ b/RequestsSignature.HttpClient/RequestsSignatureDelegatingHandler.cs
@@ -34,14 +34,11 @@ namespace RequestsSignature.HttpClient
         /// <param name="options">The signature options.</param>
         /// <param name="signatureBodySourceBuilder">The <see cref="ISignatureBodySourceBuilder"/>.</param>
         /// <param name="signatureBodySigner">The <see cref="ISignatureBodySigner"/>.</param>
-        /// <param name="innerHandler">The inner handler which is responsible for processing the HTTP response messages.</param>
         [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Not needed for HttpClient.")]
         public RequestsSignatureDelegatingHandler(
             RequestsSignatureOptions options,
             ISignatureBodySourceBuilder signatureBodySourceBuilder = null,
-            ISignatureBodySigner signatureBodySigner = null,
-            HttpMessageHandler innerHandler = null)
-            : base(innerHandler ?? new HttpClientHandler())
+            ISignatureBodySigner signatureBodySigner = null)
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _signatureBodySourceBuilder = signatureBodySourceBuilder ?? new SignatureBodySourceBuilder();


### PR DESCRIPTION
GitHub Issue: #2 

## Proposed Changes
- Bug fix

## What is the current behavior?
See Issue #2 - Error when using with the `IHttpClientFactory`

## What is the new behavior?
- Added support for the `IHttpClientBuilder` methods.
- Support for working with `IHttpClientFactory`

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [x] Updated the Changelog
- [x] Associated with an issue

[BREAKING]: Removed the `innerHandler` parameter in the `RequestsSignatureDelegatingHandler` constructor; you must now use the `InnerHandler` property.


## Other information
<!-- Please provide any additional information if necessary -->

