### PR TITLE
Fix: Postman pre-request script not working when using urlencoded bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Support for working with `IHttpClientFactory` ([Issue #2](https://github.com/nventive/RequestsSignature/issues/2)).
+- Postman pre-request script not working when using urlencoded bodies.
 
 ### Security
 


### PR DESCRIPTION
## Proposed Changes
- Bug fix

## What is the current behavior?
On some requests that uses urlencoded mode, the postman script fails (e.g. oauth2 requests).

## What is the new behavior?
- Patched Postman sdk.RequestBody implementation when body is urlencoded.
- Fixed some faulty usage of url.getHost() instead of url.getRaw();
- Prettier usage to reformat the pre-request script

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [x] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

